### PR TITLE
fix: backups accidentally triggered in some cases

### DIFF
--- a/BackupHelper/BackupCommand.cpp
+++ b/BackupHelper/BackupCommand.cpp
@@ -3,6 +3,7 @@
 #include "Backup.h"
 #include "ConfigFile.h"
 #include "Tools.h"
+#include "ScheduleAPI.h"
 using namespace std;
 
 void CmdReloadConfig(Player *p)
@@ -29,7 +30,7 @@ void CmdBackup(Player* p)
         nowPlayer = oldp;
     }
     else
-        StartBackup();
+        Schedule::nextTick(StartBackup);
 }
 
 void CmdCancel(Player* p)

--- a/BackupHelper/Plugin.cpp
+++ b/BackupHelper/Plugin.cpp
@@ -7,7 +7,7 @@
 #include "Tools.h"
 using namespace std;
 
-LL::Version ver(2, 0, 6);
+LL::Version ver(2, 0, 7);
 CSimpleIniA ini;
 
 Logger logger("BackupHelper");


### PR DESCRIPTION
详见commit中的subject内容
已测试以下情况：

- [x] 快速执行两次指令：第一次正常触发备份；第二次提示当前已有备份任务。
- [x] 执行save hold：不会触发BackupHelper的备份进程。
- [x] 在地图被挂起的情况下执行backup：提示当前已有备份任务。
- [x] 在游戏中执行backup：植入tick后（几乎）不会对mspt或tps产生影响（测试平台：E5-2660v2）